### PR TITLE
Add support for background processes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,13 @@ The format in a nutshell:
 * Lines beginning with two spaces, a greater than sign, and a space
   allow multi-line commands.
 
+* Lines beginning with two spaces, an ampersand, and a space
+  allow backgrounded commands (e.g. for setting up servers). Note that
+  backgrounded commands will be run before any other commands in the file
+  in the order in which they are defined, and they will be sent the SIGTERM
+  signal at the end of a cram test file. Make sure your backgrounded command
+  respects SIGTERM or it will continue running!
+
 * All other lines beginning with two spaces are considered command
   output.
 

--- a/cram/_process.py
+++ b/cram/_process.py
@@ -1,6 +1,8 @@
 """Utilities for running subprocesses"""
 
+from contextlib import contextmanager
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -52,3 +54,16 @@ def execute(args, stdin=None, stdout=None, stderr=None, cwd=None, env=None):
                          close_fds=os.name == 'posix')
     out, err = p.communicate(stdin)
     return out, p.returncode
+
+def to_string(string_or_bytes):
+    if isinstance(string_or_bytes, bytes):
+        return string_or_bytes.decode('utf-8')
+    return string_or_bytes
+
+@contextmanager
+def setup_procs(commands):
+    children = [subprocess.Popen(shlex.split(to_string(command)), shell=False)
+                for command in commands]
+    yield
+    for child in children:
+        child.terminate()  # sends SIGTERM


### PR DESCRIPTION
This feature allows us to setup servers at the beginning of a cram test
and interact with it. Backgrounded processes are torn down at the end of
a cram test file. One limitation to be aware of -- backgrounded
processes will be run before any other commands no matter where they are
defined in the cram test file!